### PR TITLE
Add basic sprite graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Equip different rods and flies to influence which species you might hook.
 
+The Java version now draws simple SNES-style pixel art sprites instead of plain rectangles.
+
 ## Requirements
 - Python 3.8+
 - Pygame (see `requirements.txt`)
@@ -27,7 +29,14 @@ java SierraTroutQuest
 - **Arrow Keys**: Move the player and navigate menus
 - **Space**: Cast your line and reel during a fight
 - **Enter**: Confirm selections
+- **B**: Gather wood
+- **C**: Craft upgrade or campfire
+- **F5**: Save game
+- **F9**: Load game
 - **Close Window**: Quit the game
 
-The current demo features three fishing spots with different weather and fish populations.
-Rods and flies modify your chances, and a short minigame plays whenever a fish is hooked.
+The demo now features five fishing spots with different weather, hazards and day/night cycles.
+Stamina and warmth decrease over time, so gather wood (`B`) and craft (`C`) campfires or upgrade rods.
+Press `F5` to save and `F9` to load your progress.
+
+Version 2 adds placeholder pixel art for the player, fish, tiles, and campfire to better emulate SNES-style graphics.


### PR DESCRIPTION
## Summary
- switch to simple SNES-style pixel art sprites for player, fish and tiles
- tile the background with ground and water images
- display fish sprite during fight and campfire sprite when lit
- document new graphics in README

## Testing
- `python -m py_compile sierra_trout_quest.py`
- `javac SierraTroutQuest.java`
